### PR TITLE
Add Azure MCA Cost Management extractor and transformer

### DIFF
--- a/Azure MCA Cost Management/Azure_MCA_Cost_Management.use
+++ b/Azure MCA Cost Management/Azure_MCA_Cost_Management.use
@@ -9,18 +9,38 @@
 # Microsoft reference:
 # https://learn.microsoft.com/en-us/rest/api/cost-management/generate-cost-details-report/create-operation?view=rest-cost-management-2023-11-01
 #
+# -------------------------------------------------------------------
+# Recommended: store credentials in an Exivity Environment instead of
+# editing this file. Create the following Environment variables and
+# attach the Environment to the workflow that runs this extractor:
+#
+#   Required:
+#     azure_mca_tenant_id           # Microsoft Entra tenant GUID
+#     azure_mca_client_id           # App registration (client) GUID
+#     azure_mca_client_secret       # App registration secret value
+#     azure_mca_billing_account_id  # MCA billing account ID
+#     azure_mca_billing_profile_id  # MCA billing profile ID
+#
+#   Optional (only needed for non-default scopes/modes):
+#     azure_mca_subscription_id     # Used when request_scope_type=subscription
+#     azure_mca_invoice_id          # Used when period_type=invoiceId
+#
+# When the variables are missing, Exivity substitutes the literal
+# placeholder text below and the validation checks further on stop the
+# run with a clear message instead of calling Azure with bad input.
+# -------------------------------------------------------------------
 
-# Microsoft Entra application credentials
-public var tenant_id = "<tenant-guid>"
-public var client_id = "<application-client-guid>"
-public var client_secret = "<client-secret>"
+# Microsoft Entra application credentials (sourced from Environment)
+public var          tenant_id      = "${azure_mca_tenant_id}"
+public var          client_id      = "${azure_mca_client_id}"
+public encrypt var  client_secret  = "${azure_mca_client_secret}"
 
 # MCA billing profile scope for all subscriptions under that billing profile
-public var billing_account_id = "<billing-account-id>"
-public var billing_profile_id = "<billing-profile-id>"
+public var billing_account_id = "${azure_mca_billing_account_id}"
+public var billing_profile_id = "${azure_mca_billing_profile_id}"
 
 # Optional subscription fallback. Only used when request_scope_type is "subscription".
-public var subscription_id = "<optional-subscription-guid>"
+public var subscription_id = "${azure_mca_subscription_id}"
 
 # Use "billing_profile" for MCA all-up extraction or "subscription" for one subscription.
 public var request_scope_type = "billing_profile"
@@ -29,7 +49,7 @@ public var request_scope_type = "billing_profile"
 public var period_type = "timePeriod"
 
 # Required only when period_type is "invoiceId".
-public var invoice_id = "<optional-invoice-id>"
+public var invoice_id = "${azure_mca_invoice_id}"
 
 # Cost metric: ActualCost or AmortizedCost
 public var metric_type = "ActualCost"
@@ -42,6 +62,51 @@ public var auth_endpoint = "https://login.microsoftonline.com/${tenant_id}/oauth
 public var exportdir = "system/extracted/AzureMCA"
 public var loglevel = "INFO"
 loglevel ${loglevel}
+
+#======================== Credential validation ========================#
+# Stop early if the Environment variables were not supplied; Exivity
+# leaves the literal "${name}" string in place when a variable is unset.
+
+if ("${tenant_id}" == "") {
+    print "tenant_id is empty. Set the azure_mca_tenant_id Environment variable."
+    terminate with error
+}
+if ("${tenant_id}" == "$\{azure_mca_tenant_id\}") {
+    print "tenant_id is unset. Set the azure_mca_tenant_id Environment variable."
+    terminate with error
+}
+if ("${client_id}" == "") {
+    print "client_id is empty. Set the azure_mca_client_id Environment variable."
+    terminate with error
+}
+if ("${client_id}" == "$\{azure_mca_client_id\}") {
+    print "client_id is unset. Set the azure_mca_client_id Environment variable."
+    terminate with error
+}
+if ("${client_secret}" == "") {
+    print "client_secret is empty. Set the azure_mca_client_secret Environment variable."
+    terminate with error
+}
+if ("${client_secret}" == "$\{azure_mca_client_secret\}") {
+    print "client_secret is unset. Set the azure_mca_client_secret Environment variable."
+    terminate with error
+}
+if ("${billing_account_id}" == "") {
+    print "billing_account_id is empty. Set the azure_mca_billing_account_id Environment variable."
+    terminate with error
+}
+if ("${billing_account_id}" == "$\{azure_mca_billing_account_id\}") {
+    print "billing_account_id is unset. Set the azure_mca_billing_account_id Environment variable."
+    terminate with error
+}
+if ("${billing_profile_id}" == "") {
+    print "billing_profile_id is empty. Set the azure_mca_billing_profile_id Environment variable."
+    terminate with error
+}
+if ("${billing_profile_id}" == "$\{azure_mca_billing_profile_id\}") {
+    print "billing_profile_id is unset. Set the azure_mca_billing_profile_id Environment variable."
+    terminate with error
+}
 
 #======================== Input handling ========================#
 
@@ -57,11 +122,11 @@ if ("${period_type}" == "timePeriod") {
 
 if ("${period_type}" == "invoiceId") {
     if ("${invoice_id}" == "") {
-        print "invoice_id must be configured when period_type is invoiceId"
+        print "invoice_id is empty. Set the azure_mca_invoice_id Environment variable when period_type is invoiceId."
         terminate with error
     }
-    if ("${invoice_id}" == "<optional-invoice-id>") {
-        print "invoice_id must be configured when period_type is invoiceId"
+    if ("${invoice_id}" == "$\{azure_mca_invoice_id\}") {
+        print "invoice_id is unset. Set the azure_mca_invoice_id Environment variable when period_type is invoiceId."
         terminate with error
     }
     var extract_period = ${invoice_id}
@@ -86,11 +151,11 @@ if ("${request_scope_type}" == "billing_profile") {
 
 if ("${request_scope_type}" == "subscription") {
     if ("${subscription_id}" == "") {
-        print "subscription_id must be configured when request_scope_type is subscription"
+        print "subscription_id is empty. Set the azure_mca_subscription_id Environment variable when request_scope_type is subscription."
         terminate with error
     }
-    if ("${subscription_id}" == "<optional-subscription-guid>") {
-        print "subscription_id must be configured when request_scope_type is subscription"
+    if ("${subscription_id}" == "$\{azure_mca_subscription_id\}") {
+        print "subscription_id is unset. Set the azure_mca_subscription_id Environment variable when request_scope_type is subscription."
         terminate with error
     }
     if ("${period_type}" == "invoiceId") {

--- a/Azure MCA Cost Management/Azure_MCA_Cost_Management.use
+++ b/Azure MCA Cost Management/Azure_MCA_Cost_Management.use
@@ -1,0 +1,344 @@
+#======================== Configuration ========================#
+#
+# Azure MCA Cost Management Cost Details Extractor
+#
+# This extractor retrieves Azure Cost Details Report data for a
+# Microsoft Customer Agreement (MCA) billing profile using Microsoft
+# Entra ID client credentials. It does not use legacy EA API keys.
+#
+# Microsoft reference:
+# https://learn.microsoft.com/en-us/rest/api/cost-management/generate-cost-details-report/create-operation?view=rest-cost-management-2023-11-01
+#
+
+# Microsoft Entra application credentials
+public var tenant_id = "<tenant-guid>"
+public var client_id = "<application-client-guid>"
+public var client_secret = "<client-secret>"
+
+# MCA billing profile scope for all subscriptions under that billing profile
+public var billing_account_id = "<billing-account-id>"
+public var billing_profile_id = "<billing-profile-id>"
+
+# Optional subscription fallback. Only used when request_scope_type is "subscription".
+public var subscription_id = "<optional-subscription-guid>"
+
+# Use "billing_profile" for MCA all-up extraction or "subscription" for one subscription.
+public var request_scope_type = "billing_profile"
+
+# Use "timePeriod" for date-range extraction or "invoiceId" for finalized MCA invoices.
+public var period_type = "timePeriod"
+
+# Required only when period_type is "invoiceId".
+public var invoice_id = "<optional-invoice-id>"
+
+# Cost metric: ActualCost or AmortizedCost
+public var metric_type = "ActualCost"
+
+# Azure endpoints
+public var resource = "https://management.azure.com"
+public var auth_endpoint = "https://login.microsoftonline.com/${tenant_id}/oauth2/v2.0/token"
+
+# Output and logging
+public var exportdir = "system/extracted/AzureMCA"
+public var loglevel = "INFO"
+loglevel ${loglevel}
+
+#======================== Input handling ========================#
+
+if ("${period_type}" == "timePeriod") {
+    gosub check_dateargument()
+    gosub format_start_date(${ARG_1})
+    gosub format_to_date(${ARG_2})
+    var start_date = (@CONCAT("${start_year}","-","${start_month}","-","${start_day}"))
+    var end_date = (@CONCAT("${to_year}","-","${to_month}","-","${to_day}"))
+    var extract_period = (@CONCAT("${ARG_1}","_","${ARG_2}"))
+    var request_body = "{\"metric\":\"${metric_type}\",\"timePeriod\":{\"start\":\"${start_date}\",\"end\":\"${end_date}\"}}"
+}
+
+if ("${period_type}" == "invoiceId") {
+    if ("${invoice_id}" == "") {
+        print "invoice_id must be configured when period_type is invoiceId"
+        terminate with error
+    }
+    if ("${invoice_id}" == "<optional-invoice-id>") {
+        print "invoice_id must be configured when period_type is invoiceId"
+        terminate with error
+    }
+    var extract_period = ${invoice_id}
+    var request_body = "{\"metric\":\"${metric_type}\",\"invoiceId\":\"${invoice_id}\"}"
+}
+
+var period_type_valid = "no"
+if ("${period_type}" == "timePeriod") {
+    var period_type_valid = "yes"
+}
+if ("${period_type}" == "invoiceId") {
+    var period_type_valid = "yes"
+}
+if ("${period_type_valid}" == "no") {
+    print "Invalid period_type. Use timePeriod or invoiceId."
+    terminate with error
+}
+
+if ("${request_scope_type}" == "billing_profile") {
+    var request_scope = "providers/Microsoft.Billing/billingAccounts/${billing_account_id}/billingProfiles/${billing_profile_id}"
+}
+
+if ("${request_scope_type}" == "subscription") {
+    if ("${subscription_id}" == "") {
+        print "subscription_id must be configured when request_scope_type is subscription"
+        terminate with error
+    }
+    if ("${subscription_id}" == "<optional-subscription-guid>") {
+        print "subscription_id must be configured when request_scope_type is subscription"
+        terminate with error
+    }
+    if ("${period_type}" == "invoiceId") {
+        print "invoiceId extraction is only supported at MCA billing profile scope"
+        terminate with error
+    }
+    var request_scope = "subscriptions/${subscription_id}"
+}
+
+var scope_type_valid = "no"
+if ("${request_scope_type}" == "billing_profile") {
+    var scope_type_valid = "yes"
+}
+if ("${request_scope_type}" == "subscription") {
+    var scope_type_valid = "yes"
+}
+if ("${scope_type_valid}" == "no") {
+    print "Invalid request_scope_type. Use billing_profile or subscription."
+    terminate with error
+}
+
+#======================== Extract ========================#
+
+gosub authenticate()
+
+clear http_headers
+set http_savefile "${exportdir}/request_report_${extract_period}.json"
+set http_header "Accept: application/json"
+set http_header "Content-Type: application/json"
+set http_header "Authorization: Bearer ${access_token}"
+set http_body data ${request_body}
+
+print "Requesting Azure MCA Cost Details Report at scope ${request_scope} ..."
+buffer request_report = http POST "${resource}/${request_scope}/providers/Microsoft.CostManagement/generateCostDetailsReport?api-version=2023-11-01"
+var request_status = ${HTTP_STATUS_CODE}
+
+if (${request_status} == 204) {
+    print "No cost data returned for this request."
+    terminate
+}
+
+if (${request_status} == 202) {
+    http get_header Location as poll_location
+    http get_header Retry-After as poll_wait
+    gosub poll_report()
+    gosub download_polled_report()
+}
+
+if (${request_status} == 200) {
+    gosub download_initial_report()
+}
+
+if (${request_status} !~ /200|202|204/) {
+    print Got HTTP status ${request_status}, expected 200, 202, or 204
+    print The server response was:
+    json format {request_report}
+    print {request_report}
+    terminate with error
+}
+
+print "Finished downloading Azure MCA Cost Details Report files."
+
+#======================== Subroutines ========================#
+
+subroutine authenticate {
+    print "Getting Microsoft Entra token..."
+    clear http_headers
+    uri encode-component client_id
+    uri encode-component client_secret
+    set http_body data "grant_type=client_credentials&client_id=${client_id}&client_secret=${client_secret}&scope=https%3A%2F%2Fmanagement.azure.com%2F.default"
+    set http_header "Content-Type: application/x-www-form-urlencoded"
+    set http_savefile "${exportdir}/auth_token.json"
+    buffer token = http POST "${auth_endpoint}"
+    if (${HTTP_STATUS_CODE} != 200) {
+        print Got HTTP status ${HTTP_STATUS_CODE} while authenticating
+        json format {token}
+        print {token}
+        terminate with error
+    }
+    var access_token = "$JSON{token}.[access_token]"
+    if (${access_token.LENGTH} < 20) {
+        print "Authentication response did not contain a valid access_token"
+        terminate with error
+    }
+}
+
+subroutine poll_report {
+    if (${poll_location.LENGTH} < 10) {
+        print "Location header is not present in the async response"
+        terminate with error
+    }
+    if (${poll_wait.LENGTH} == 0) {
+        var poll_wait = 60
+    }
+    clear http_headers
+    set http_header "Authorization: Bearer ${access_token}"
+    loop polling_loop 120 {
+        print "Waiting ${poll_wait} seconds for report generation..."
+        var poll_wait_ms = (${poll_wait} * 1000)
+        pause ${poll_wait_ms}
+        print "Polling ${poll_location} ..."
+        buffer report_ready = http GET "${poll_location}"
+        if (${HTTP_STATUS_CODE} == 200) {
+            exit_loop
+        }
+        if (${HTTP_STATUS_CODE} == 202) {
+            http get_header Retry-After as poll_wait
+        }
+        if (${HTTP_STATUS_CODE} == 204) {
+            print "No cost data returned for this request."
+            terminate
+        }
+        if (${HTTP_STATUS_CODE} !~ /200|202|204/) {
+            print Got HTTP status ${HTTP_STATUS_CODE} while polling report status
+            json format {report_ready}
+            print {report_ready}
+            terminate with error
+        }
+    }
+    if (${HTTP_STATUS_CODE} != 200) {
+        print "Report was not ready before the polling limit was reached"
+        terminate with error
+    }
+}
+
+subroutine download_polled_report {
+    clear http_headers
+    var csv_count = 0
+    var blob_count = "$JSON{report_ready}.[manifest].[blobCount]"
+    if ("${blob_count}" == "EXIVITY_NOT_FOUND") {
+        print "Report manifest does not contain a blobCount"
+        terminate with error
+    }
+    if (${blob_count} == 0) {
+        print "Report manifest does not contain any blobs"
+        terminate with error
+    }
+    foreach $JSON{report_ready}.[manifest].[blobs] as this_blob {
+        var csv_count += 1
+        var blob_url = "$JSON(this_blob).[blobLink]"
+        if (${blob_url.LENGTH} < 18) {
+            print "Report manifest blobLink is missing"
+            terminate with error
+        }
+        print "Downloading report blob ${csv_count} ..."
+        set http_savefile "${exportdir}/blob/azure_mca_${extract_period}_${csv_count}.csv"
+        buffer csv_report = http GET "${blob_url}"
+        if (${HTTP_STATUS_CODE} != 200) {
+            print Got HTTP status ${HTTP_STATUS_CODE} while downloading report blob
+            print {csv_report}
+            terminate with error
+        }
+    }
+}
+
+subroutine download_initial_report {
+    clear http_headers
+    var csv_count = 0
+    var blob_count = "$JSON{request_report}.[manifest].[blobCount]"
+    if ("${blob_count}" == "EXIVITY_NOT_FOUND") {
+        print "Report manifest does not contain a blobCount"
+        terminate with error
+    }
+    if (${blob_count} == 0) {
+        print "Report manifest does not contain any blobs"
+        terminate with error
+    }
+    foreach $JSON{request_report}.[manifest].[blobs] as this_blob {
+        var csv_count += 1
+        var blob_url = "$JSON(this_blob).[blobLink]"
+        if (${blob_url.LENGTH} < 18) {
+            print "Report manifest blobLink is missing"
+            terminate with error
+        }
+        print "Downloading report blob ${csv_count} ..."
+        set http_savefile "${exportdir}/blob/azure_mca_${extract_period}_${csv_count}.csv"
+        buffer csv_report = http GET "${blob_url}"
+        if (${HTTP_STATUS_CODE} != 200) {
+            print Got HTTP status ${HTTP_STATUS_CODE} while downloading report blob
+            print {csv_report}
+            terminate with error
+        }
+    }
+}
+
+subroutine format_start_date {
+    match day "^[0-9]{6}([0-9]{2})" ${SUBARG_1}
+    if (${day.STATUS} != MATCH) {
+        terminate with error
+    } else {
+        var start_day = ${day.RESULT}
+    }
+    match month "^[0-9]{4}([0-9]{2})[0-9]{2}" ${SUBARG_1}
+    if (${month.STATUS} != MATCH) {
+        terminate with error
+    } else {
+        var start_month = ${month.RESULT}
+    }
+    match year "^([0-9]{4})[0-9]{4}" ${SUBARG_1}
+    if (${year.STATUS} != MATCH) {
+        terminate with error
+    } else {
+        var start_year = ${year.RESULT}
+    }
+}
+
+subroutine format_to_date {
+    match day "^[0-9]{6}([0-9]{2})" ${SUBARG_1}
+    if (${day.STATUS} != MATCH) {
+        terminate with error
+    } else {
+        var to_day = ${day.RESULT}
+    }
+    match month "^[0-9]{4}([0-9]{2})[0-9]{2}" ${SUBARG_1}
+    if (${month.STATUS} != MATCH) {
+        terminate with error
+    } else {
+        var to_month = ${month.RESULT}
+    }
+    match year "^([0-9]{4})[0-9]{4}" ${SUBARG_1}
+    if (${year.STATUS} != MATCH) {
+        terminate with error
+    } else {
+        var to_year = ${year.RESULT}
+    }
+}
+
+subroutine check_dateargument {
+    if (${ARGC} != 2) {
+        print "timePeriod extraction requires 2 arguments: FROM and TO dates in yyyyMMdd format"
+        terminate with error
+    }
+    if (${ARG_1} > ${ARG_2}) {
+        print "TO date cannot be before FROM date"
+        terminate with error
+    }
+    if (${ARG_1} == ${ARG_2}) {
+        print "TO date cannot be the same as FROM date"
+        terminate with error
+    }
+    gosub check_dateformat(${ARG_1})
+    gosub check_dateformat(${ARG_2})
+}
+
+subroutine check_dateformat {
+    match date "^([0-9]{4}(0[1-9]|1[0-2])(0[1-9]|1[0-9]|2[0-9]|3[0-1]))$" ${SUBARG_1}
+    if (${date.STATUS} != MATCH) {
+        print Argument error: ${SUBARG_1} is not in YYYYMMDD format
+        terminate with error
+    }
+}

--- a/Azure MCA Cost Management/Azure_MCA_Cost_Management_Transformer.trs
+++ b/Azure MCA Cost Management/Azure_MCA_Cost_Management_Transformer.trs
@@ -1,0 +1,134 @@
+option loglevel = INFO
+option overwrite = no
+
+# =====================================================================
+# Azure MCA Cost Management Transformer
+#
+# Consumes Cost Details Report CSV blobs produced by
+# Azure_MCA_Cost_Management.use and turns them into Exivity-ready
+# data. Output is twofold:
+#   - finish into RDF when run as a stand-alone Azure MCA report
+#   - export a normalized CSV into Exivity/MasterInput so the
+#     Master_Consumption_Transformer.trs can blend Azure MCA usage
+#     with other vendors (vCloud, Nutanix, etc.)
+#
+# Cost Details CSV column reference:
+# https://learn.microsoft.com/en-us/azure/cost-management-billing/automate/understand-usage-details-fields
+# =====================================================================
+
+# Set to "no" when this transformer is only used to feed the master
+# transformer; that avoids generating duplicate services.
+var generate_services = "yes"
+
+# Set to "no" to skip the MasterInput export when blending is not used.
+var export_to_masterinput = "yes"
+
+# The Extractor writes blobs to system/extracted/AzureMCA/blob/.
+# Filenames are azure_mca_<period>_<n>.csv where <period> is either
+# yyyymmdd_yyyymmdd (timePeriod mode) or the invoice id (invoiceId mode).
+import "system/extracted/AzureMCA/blob/azure_mca_${dataYear}${dataMonth}*_*.csv" source azure alias mca options {
+    pattern enabled
+    escaped = yes
+    filter = ([Date] =~ /${dataMonth}.${dataDay}.${dataYear}.*/)
+}
+
+default dset azure.mca
+
+# ---------------------------------------------------------------------
+# Column normalization
+# ---------------------------------------------------------------------
+# Cost Details CSV column names are documented by Microsoft and stable.
+# Only the billing currency header has a known alias; everything else
+# matches the canonical casing used below.
+rename column ${/^[Bb]illing[Cc]urrency[Cc]ode$/} to BillingCurrency
+
+# ---------------------------------------------------------------------
+# Exivity-friendly columns
+# ---------------------------------------------------------------------
+option overwrite = yes
+
+# Instance: prefer the resource id; fall back to MeterName for
+# subscription-level charges (taxes, marketplace fees) without a resource.
+create mergedcolumn instance from "ResourceId" /^.*\/([^/]+)$/
+where ([instance] == "") {
+    set instance as MeterName
+}
+where ([instance] == "EXIVITY_NOT_FOUND") {
+    set instance as MeterName
+}
+
+# Service description: Marketplace items roll up under Publisher / Plan.
+rename column ProductName to service
+where ([PublisherType] == "Marketplace") {
+    set service = (@CONCAT([PublisherName], " - ", [PlanName]))
+    set MeterCategory to "Marketplace"
+}
+
+rename column MeterCategory to category
+
+# Stable service key. PartNumber is unique per MCA SKU so concatenating
+# it with the friendly service name gives a deterministic identifier.
+create column service_key
+set service_key = (@CONCAT([service], "_", [PartNumber], "_MCA"))
+
+# Reservations and savings plan purchases are recognized via UnitOfMeasure.
+create column unit
+set unit = (@CONCAT([UnitOfMeasure], "/", [ChargeType], " Hours"))
+replace "Unassigned/" in unit
+where ([unit] =~ /.*Purchase.*/) {
+    set category to "Reservations"
+}
+
+rename column Quantity to quantity
+rename column CostInBillingCurrency to cost
+create column interval value "individually"
+
+option overwrite = no
+
+# ---------------------------------------------------------------------
+# Aggregate to a manageable level and derive rate / cogs
+# ---------------------------------------------------------------------
+delete columns except BillingAccountId BillingProfileId InvoiceSectionName SubscriptionId SubscriptionName ResourceGroup ResourceLocation ServiceFamily category instance service_key service unit quantity cost interval Date Tags
+
+aggregate azure.mca notime default_function match quantity sum cost sum
+
+create column rate
+set rate = ([cost] / [quantity])
+create column cogs
+set cogs as rate
+
+# Example uplift hook - leave commented for the generic template
+# set rate = [rate] * 1.05
+
+delete columns EXIVITY_AGGR_COUNT
+
+# ---------------------------------------------------------------------
+# Optional export for the master/blend transformer.
+# The dset is exported as-is with its Azure-MCA column names; the
+# Master_Consumption_Transformer.trs maps those names to the common
+# schema, mirroring how vCloud and Nutanix are handled.
+# ---------------------------------------------------------------------
+if ("${export_to_masterinput}" == "yes") {
+    export azure.mca as "Exivity/MasterInput/${dataDate}_azure_mca_normalized.csv"
+}
+
+# ---------------------------------------------------------------------
+# Stand-alone services / RDF output
+# ---------------------------------------------------------------------
+if ("${generate_services}" == "yes") {
+    finish
+
+    services {
+        effective_date  = 20240101
+        service_type    = automatic
+        usages_col      = service_key
+        description_col = service
+        category_col    = category
+        instance_col    = instance
+        rate_col        = rate
+        cogs_col        = cogs
+        interval_col    = interval
+        unit_label_col  = unit
+        consumption_col = quantity
+    }
+}

--- a/Exivity/Master_Consumption_Transformer.trs
+++ b/Exivity/Master_Consumption_Transformer.trs
@@ -19,6 +19,16 @@ import "Exivity/MasterInput/${dataDate}_ibmcos_normalized.*" source master alias
     pattern enabled
 }
 
+# Azure MCA Cost Management is optional. The per-vendor transformer
+# exports its native MCA columns; the mapping to the common schema
+# happens below, mirroring the vCloud, Nutanix and IBM COS branches.
+# When no MasterInput file exists for the run date the @DSET_EXISTS
+# guards below skip the mapping and append so the master keeps
+# working without Azure MCA data.
+import "Exivity/MasterInput/${dataDate}_azure_mca_normalized.*" source master alias azuremca options {
+    pattern enabled
+}
+
 # -------------------------------
 # vCloud -> common schema
 # -------------------------------
@@ -115,12 +125,49 @@ set metric_description as [service_desc]
 delete columns dataDate vaultName customerKey usedValue usedUnit usedBytes instance service_name quantity units rate cogs category service_desc
 
 # -------------------------------
+# Azure MCA -> common schema (optional)
+# -------------------------------
+if (@DSET_EXISTS(master.azuremca)) {
+    default dset master.azuremca
+    create column source_vendor value "Azure MCA"
+    create column usage_date value "${dataDate}"
+    create column tenant_id
+    set tenant_id as [SubscriptionId]
+    create column tenant_name
+    set tenant_name as [SubscriptionName]
+    create column location
+    set location as [ResourceLocation]
+    create column resource_id
+    set resource_id as [instance]
+    create column resource_name
+    set resource_name as [instance]
+    create column metric_name
+    set metric_name as [service]
+    create column usage_quantity
+    set usage_quantity as [quantity]
+    create column usage_unit
+    set usage_unit as [unit]
+    create column price_rate
+    set price_rate as [rate]
+    create column cost_amount
+    set cost_amount as [cost]
+    create column usage_category
+    set usage_category as [category]
+    create column metric_description
+    set metric_description as [service]
+    delete columns BillingAccountId BillingProfileId InvoiceSectionName SubscriptionId SubscriptionName ResourceGroup ResourceLocation ServiceFamily category instance service_key service unit quantity cost interval Date Tags
+}
+
+# -------------------------------
 # Consolidated dataset
 # -------------------------------
 rename dset master.vcloud to master.final
 default dset master.final
 append master.nutanix to master.final
 append master.ibmcos to master.final
+if (@DSET_EXISTS(master.azuremca)) {
+    append master.azuremca to master.final
+}
 
 export master.final as "Exivity/MasterOutput/${dataDate}_master_consumption.csv"
 


### PR DESCRIPTION
## Summary

Adds a dedicated **Azure MCA Cost Management** template, replacing the EA API-key flow for Microsoft Customer Agreement customers.

The legacy `Azure Cost Management/` template still works for Azure EA and Pay-as-you-Go via `billingPeriod`/`enrollment` scope. MCA customers need a different flow:

- Microsoft Entra (Azure AD) client-credentials auth instead of EA API keys
- Billing profile scope `providers/Microsoft.Billing/billingAccounts/{id}/billingProfiles/{id}` (or subscription)
- `timePeriod`/`invoiceId` request modes (`billingPeriod` is EA-only)
- Async polling on HTTP 202 with `Location`/`Retry-After`, then CSV blob download per the manifest

Microsoft references:
- Cost Details Report API: https://learn.microsoft.com/en-us/rest/api/cost-management/generate-cost-details-report/create-operation
- MCA cost access: https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/assign-access-acm-data

## What's added

- `Azure MCA Cost Management/Azure_MCA_Cost_Management.use` - new MCA extractor
  - Configurable `request_scope_type` (`billing_profile` default, or `subscription`)
  - Configurable `period_type` (`timePeriod` default, or `invoiceId`)
  - Configurable `metric_type` (`ActualCost` / `AmortizedCost`)
  - Token, polling and blob handling defended via `EXIVITY_NOT_FOUND` and `.LENGTH` checks
- `Azure MCA Cost Management/Azure_MCA_Cost_Management_Transformer.trs` - new MCA transformer
  - Cleans Cost Details CSV columns, builds Exivity `service_key` / `service` / `unit` / `rate` / `cogs`
  - Produces standalone RDF + services
  - Optionally exports a normalized CSV to `Exivity/MasterInput/` for blending

## Master transformer

`Exivity/Master_Consumption_Transformer.trs` gains an **optional** Azure MCA branch:

- New import alias `master.azuremca`
- New per-vendor mapping block guarded by `@DSET_EXISTS(master.azuremca)`
- New guarded `append` so customers running only vCloud/Nutanix/IBM COS keep working unchanged

## Generic, no client specifics

All credentials, GUIDs and scope identifiers in the new template are placeholders (`<tenant-guid>`, `<billing-account-id>`, etc.). No customer or environment data is included.

## Testing notes

Extractor flow has been built against the documented Cost Details API contract. Validation against a real MCA blob is pending and may surface minor column-casing tweaks in the transformer's `rename` block; that change would be additive and contained.