### PR TITLE
Align Azure MCA transformer with tested Cost Details flow

### DIFF
--- a/Azure MCA Cost Management/Azure_MCA_Cost_Management.use
+++ b/Azure MCA Cost Management/Azure_MCA_Cost_Management.use
@@ -116,7 +116,7 @@ if ("${period_type}" == "timePeriod") {
     gosub format_to_date(${ARG_2})
     var start_date = (@CONCAT("${start_year}","-","${start_month}","-","${start_day}"))
     var end_date = (@CONCAT("${to_year}","-","${to_month}","-","${to_day}"))
-    var extract_period = (@CONCAT("${ARG_1}","_","${ARG_2}"))
+    var extract_period = "${ARG_1}"
     var request_body = "{\"metric\":\"${metric_type}\",\"timePeriod\":{\"start\":\"${start_date}\",\"end\":\"${end_date}\"}}"
 }
 

--- a/Azure MCA Cost Management/Azure_MCA_Cost_Management.use
+++ b/Azure MCA Cost Management/Azure_MCA_Cost_Management.use
@@ -112,12 +112,9 @@ if ("${billing_profile_id}" == "$\{azure_mca_billing_profile_id\}") {
 
 if ("${period_type}" == "timePeriod") {
     gosub check_dateargument()
-    gosub format_start_date(${ARG_1})
-    gosub format_to_date(${ARG_2})
-    var start_date = (@CONCAT("${start_year}","-","${start_month}","-","${start_day}"))
-    var end_date = (@CONCAT("${to_year}","-","${to_month}","-","${to_day}"))
-    var extract_period = "${ARG_1}"
-    var request_body = "{\"metric\":\"${metric_type}\",\"timePeriod\":{\"start\":\"${start_date}\",\"end\":\"${end_date}\"}}"
+    var date_counter = (@DATEDIFF(${ARG_2},${ARG_1}))
+    var date_counter = (${date_counter}+1)
+    var extract_date = ${ARG_1}
 }
 
 if ("${period_type}" == "invoiceId") {
@@ -181,39 +178,22 @@ if ("${scope_type_valid}" == "no") {
 
 gosub authenticate()
 
-clear http_headers
-set http_savefile "${exportdir}/request_report_${extract_period}.json"
-set http_header "Accept: application/json"
-set http_header "Content-Type: application/json"
-set http_header "Authorization: Bearer ${access_token}"
-set http_body data ${request_body}
-
-print "Requesting Azure MCA Cost Details Report at scope ${request_scope} ..."
-buffer request_report = http POST "${resource}/${request_scope}/providers/Microsoft.CostManagement/generateCostDetailsReport?api-version=2023-11-01"
-var request_status = ${HTTP_STATUS_CODE}
-
-if (${request_status} == 204) {
-    print "No cost data returned for this request."
-    terminate
+if ("${period_type}" == "timePeriod") {
+    loop extract_days ${date_counter} {
+        var extract_period = ${extract_date}
+        gosub format_start_date(${extract_date})
+        var next_date = (@DATEADD(${extract_date}, 1))
+        gosub format_to_date(${next_date})
+        var start_date = (@CONCAT("${start_year}","-","${start_month}","-","${start_day}"))
+        var end_date = (@CONCAT("${to_year}","-","${to_month}","-","${to_day}"))
+        var request_body = "{\"metric\":\"${metric_type}\",\"timePeriod\":{\"start\":\"${start_date}\",\"end\":\"${end_date}\"}}"
+        gosub request_report()
+        var extract_date = ${next_date}
+    }
 }
 
-if (${request_status} == 202) {
-    http get_header Location as poll_location
-    http get_header Retry-After as poll_wait
-    gosub poll_report()
-    gosub download_polled_report()
-}
-
-if (${request_status} == 200) {
-    gosub download_initial_report()
-}
-
-if (${request_status} !~ /200|202|204/) {
-    print Got HTTP status ${request_status}, expected 200, 202, or 204
-    print The server response was:
-    json format {request_report}
-    print {request_report}
-    terminate with error
+if ("${period_type}" == "invoiceId") {
+    gosub request_report()
 }
 
 print "Finished downloading Azure MCA Cost Details Report files."
@@ -242,7 +222,46 @@ subroutine authenticate {
     }
 }
 
+subroutine request_report {
+    clear http_headers
+    set http_savefile "${exportdir}/request_report_${extract_period}.json"
+    set http_header "Accept: application/json"
+    set http_header "Content-Type: application/json"
+    set http_header "Authorization: Bearer ${access_token}"
+    set http_body data ${request_body}
+
+    print "Requesting Azure MCA Cost Details Report for ${extract_period} at scope ${request_scope} ..."
+    buffer request_report = http POST "${resource}/${request_scope}/providers/Microsoft.CostManagement/generateCostDetailsReport?api-version=2023-11-01"
+    var request_status = ${HTTP_STATUS_CODE}
+
+    if (${request_status} == 204) {
+        print "No cost data returned for ${extract_period}."
+    }
+
+    if (${request_status} == 202) {
+        http get_header Location as poll_location
+        http get_header Retry-After as poll_wait
+        gosub poll_report()
+        if ("${report_ready_status}" == "yes") {
+            gosub download_polled_report()
+        }
+    }
+
+    if (${request_status} == 200) {
+        gosub download_initial_report()
+    }
+
+    if (${request_status} !~ /200|202|204/) {
+        print Got HTTP status ${request_status}, expected 200, 202, or 204
+        print The server response was:
+        json format {request_report}
+        print {request_report}
+        terminate with error
+    }
+}
+
 subroutine poll_report {
+    var report_ready_status = "no"
     if (${poll_location.LENGTH} < 10) {
         print "Location header is not present in the async response"
         terminate with error
@@ -259,14 +278,15 @@ subroutine poll_report {
         print "Polling ${poll_location} ..."
         buffer report_ready = http GET "${poll_location}"
         if (${HTTP_STATUS_CODE} == 200) {
+            var report_ready_status = "yes"
             exit_loop
         }
         if (${HTTP_STATUS_CODE} == 202) {
             http get_header Retry-After as poll_wait
         }
         if (${HTTP_STATUS_CODE} == 204) {
-            print "No cost data returned for this request."
-            terminate
+            print "No cost data returned for ${extract_period}."
+            exit_loop
         }
         if (${HTTP_STATUS_CODE} !~ /200|202|204/) {
             print Got HTTP status ${HTTP_STATUS_CODE} while polling report status
@@ -275,9 +295,11 @@ subroutine poll_report {
             terminate with error
         }
     }
-    if (${HTTP_STATUS_CODE} != 200) {
-        print "Report was not ready before the polling limit was reached"
-        terminate with error
+    if ("${report_ready_status}" == "no") {
+        if (${HTTP_STATUS_CODE} != 204) {
+            print "Report was not ready before the polling limit was reached"
+            terminate with error
+        }
     }
 }
 
@@ -291,6 +313,10 @@ subroutine download_polled_report {
     }
     if (${blob_count} == 0) {
         print "Report manifest does not contain any blobs"
+        terminate with error
+    }
+    if (${blob_count} > 1) {
+        print "Report manifest contains ${blob_count} blobs for ${extract_period}. The transformer currently supports one blob per day."
         terminate with error
     }
     foreach $JSON{report_ready}.[manifest].[blobs] as this_blob {
@@ -321,6 +347,10 @@ subroutine download_initial_report {
     }
     if (${blob_count} == 0) {
         print "Report manifest does not contain any blobs"
+        terminate with error
+    }
+    if (${blob_count} > 1) {
+        print "Report manifest contains ${blob_count} blobs for ${extract_period}. The transformer currently supports one blob per day."
         terminate with error
     }
     foreach $JSON{request_report}.[manifest].[blobs] as this_blob {
@@ -390,10 +420,6 @@ subroutine check_dateargument {
     }
     if (${ARG_1} > ${ARG_2}) {
         print "TO date cannot be before FROM date"
-        terminate with error
-    }
-    if (${ARG_1} == ${ARG_2}) {
-        print "TO date cannot be the same as FROM date"
         terminate with error
     }
     gosub check_dateformat(${ARG_1})

--- a/Azure MCA Cost Management/Azure_MCA_Cost_Management_Transformer.trs
+++ b/Azure MCA Cost Management/Azure_MCA_Cost_Management_Transformer.trs
@@ -1,6 +1,3 @@
-option loglevel = INFO
-option overwrite = no
-
 # =====================================================================
 # Azure MCA Cost Management Transformer
 #
@@ -23,84 +20,102 @@ var generate_services = "yes"
 # Set to "no" to skip the MasterInput export when blending is not used.
 var export_to_masterinput = "yes"
 
-# The Extractor writes blobs to system/extracted/AzureMCA/blob/.
-# Filenames are azure_mca_<period>_<n>.csv where <period> is either
-# yyyymmdd_yyyymmdd (timePeriod mode) or the invoice id (invoiceId mode).
-import "system/extracted/AzureMCA/blob/azure_mca_${dataYear}${dataMonth}*_*.csv" source azure alias mca options {
+option loglevel = DEBUGX
+option embed = yes
+option mode = permissive
+
+# The extractor writes blobs to system/extracted/AzureMCA/blob/ using
+# azure_mca_<dataDate>_<n>.csv. Preprocess the first blob before import
+# so Transcript handles the Cost Details CSV consistently.
+preprocess "system/extracted/AzureMCA/blob/azure_mca_${dataDate}_1.csv" as "system/extracted/AzureMCA/blob/azure_mca_${dataDate}_PP.csv"
+
+import "system/extracted/AzureMCA/blob/azure_mca_${dataDate}_PP.csv" source azure alias mca options {
     pattern enabled
     escaped = yes
-    filter = ([Date] =~ /${dataMonth}.${dataDay}.${dataYear}.*/)
+    filter = ([date] =~ /${dataMonth}.${dataDay}.${dataYear}.*/)
 }
 
 default dset azure.mca
-
-# ---------------------------------------------------------------------
-# Column normalization
-# ---------------------------------------------------------------------
-# Cost Details CSV column names are documented by Microsoft and stable.
-# Only the billing currency header has a known alias; everything else
-# matches the canonical casing used below.
-rename column ${/^[Bb]illing[Cc]urrency[Cc]ode$/} to BillingCurrency
 
 # ---------------------------------------------------------------------
 # Exivity-friendly columns
 # ---------------------------------------------------------------------
 option overwrite = yes
 
-# Instance: prefer the resource id; fall back to MeterName for
-# subscription-level charges (taxes, marketplace fees) without a resource.
-create mergedcolumn instance from "ResourceId" /^.*\/([^/]+)$/
+rename column billingCurrency to BillingCurrency
+rename column meterCategory to category
+
+create mergedcolumn instance from ResourceId /.*\/(.*)$/
+lowercase values in column instance
+
 where ([instance] == "") {
-    set instance as MeterName
+    set instance as meterName
 }
 where ([instance] == "EXIVITY_NOT_FOUND") {
-    set instance as MeterName
+    set instance as meterName
 }
 
-# Service description: Marketplace items roll up under Publisher / Plan.
-rename column ProductName to service
-where ([PublisherType] == "Marketplace") {
-    set service = (@CONCAT([PublisherName], " - ", [PlanName]))
-    set MeterCategory to "Marketplace"
+where ([meterRegion] == "") {
+    set meterRegion as resourceLocation
+}
+where ([meterRegion] == "EXIVITY_NOT_FOUND") {
+    set meterRegion as resourceLocation
 }
 
-rename column MeterCategory to category
+create mergedcolumn service_key separator "|" from pricingModel ProductId meterId meterRegion
+create mergedcolumn service_name separator "-" from ProductName meterName
 
-# Stable service key. PartNumber is unique per MCA SKU so concatenating
-# it with the friendly service name gives a deterministic identifier.
-create column service_key
-set service_key = (@CONCAT([service], "_", [PartNumber], "_MCA"))
+where ([publisherType] == "Marketplace") {
+    set service_name = (@CONCAT([publisherName], "-", [productOrderName]))
+    set category to "Marketplace"
+}
 
-# Reservations and savings plan purchases are recognized via UnitOfMeasure.
 create column unit
-set unit = (@CONCAT([UnitOfMeasure], "/", [ChargeType], " Hours"))
+set unit = (@CONCAT([unitOfMeasure], "/", [chargeType], " Hours"))
 replace "Unassigned/" in unit
+
 where ([unit] =~ /.*Purchase.*/) {
     set category to "Reservations"
 }
 
-rename column Quantity to quantity
-rename column CostInBillingCurrency to cost
+rename column costInBillingCurrency to cost
 create column interval value "individually"
 
 option overwrite = no
 
 # ---------------------------------------------------------------------
-# Aggregate to a manageable level and derive rate / cogs
+# Calculate one rate per service key, then correlate it back to detail
+# rows so the original consumption rows stay intact for reporting.
 # ---------------------------------------------------------------------
-delete columns except BillingAccountId BillingProfileId InvoiceSectionName SubscriptionId SubscriptionName ResourceGroup ResourceLocation ServiceFamily category instance service_key service unit quantity cost interval Date Tags
+delete columns except billingAccountId billingAccountName billingProfileId billingProfileName invoiceSectionName SubscriptionId subscriptionName ResourceGroup resourceGroupName resourceLocation serviceFamily category instance service_key service_name unit quantity cost interval date
 
-aggregate azure.mca notime default_function match quantity sum cost sum
+where ([service_key] != "") {
+    copy rows to azure.tmp
+}
 
+default dset azure.tmp
+delete columns except service_key quantity cost
+aggregate azure.tmp notime default_function match quantity sum cost sum
+delete columns EXIVITY_AGGR_COUNT
 create column rate
 set rate = ([cost] / [quantity])
+
+default dset azure.mca
+correlate rate using service_key assuming azure.tmp
 create column cogs
 set cogs as rate
 
+where ([subscriptionName] == "") {
+    set subscriptionName to "Subscription_Undefined"
+    set SubscriptionId to "Subscription_Undefined"
+}
+where ([subscriptionName] == "EXIVITY_NOT_FOUND") {
+    set subscriptionName to "Subscription_Undefined"
+    set SubscriptionId to "Subscription_Undefined"
+}
+
 # Example uplift hook - leave commented for the generic template
 # set rate = [rate] * 1.05
-
-delete columns EXIVITY_AGGR_COUNT
 
 # ---------------------------------------------------------------------
 # Optional export for the master/blend transformer.
@@ -116,13 +131,14 @@ if ("${export_to_masterinput}" == "yes") {
 # Stand-alone services / RDF output
 # ---------------------------------------------------------------------
 if ("${generate_services}" == "yes") {
+    option services = overwrite
     finish
 
     services {
-        effective_date  = 20240101
+        effective_date  = 20260101
         service_type    = automatic
         usages_col      = service_key
-        description_col = service
+        description_col = service_name
         category_col    = category
         instance_col    = instance
         rate_col        = rate

--- a/Exivity/Master_Consumption_Transformer.trs
+++ b/Exivity/Master_Consumption_Transformer.trs
@@ -134,15 +134,15 @@ if (@DSET_EXISTS(master.azuremca)) {
     create column tenant_id
     set tenant_id as [SubscriptionId]
     create column tenant_name
-    set tenant_name as [SubscriptionName]
+    set tenant_name as [subscriptionName]
     create column location
-    set location as [ResourceLocation]
+    set location as [resourceLocation]
     create column resource_id
     set resource_id as [instance]
     create column resource_name
     set resource_name as [instance]
     create column metric_name
-    set metric_name as [service]
+    set metric_name as [service_name]
     create column usage_quantity
     set usage_quantity as [quantity]
     create column usage_unit
@@ -150,12 +150,12 @@ if (@DSET_EXISTS(master.azuremca)) {
     create column price_rate
     set price_rate as [rate]
     create column cost_amount
-    set cost_amount as [cost]
+    set cost_amount as [cogs]
     create column usage_category
     set usage_category as [category]
     create column metric_description
-    set metric_description as [service]
-    delete columns BillingAccountId BillingProfileId InvoiceSectionName SubscriptionId SubscriptionName ResourceGroup ResourceLocation ServiceFamily category instance service_key service unit quantity cost interval Date Tags
+    set metric_description as [service_name]
+    delete columns billingAccountId billingAccountName billingProfileId billingProfileName invoiceSectionName SubscriptionId subscriptionName ResourceGroup resourceGroupName resourceLocation serviceFamily category instance service_key service_name unit quantity cost interval date rate cogs
 }
 
 # -------------------------------


### PR DESCRIPTION
## Summary

Aligns the Azure MCA templates with the tested Cost Details extractor/transformer flow supplied after the initial PR was merged.

## Changes

- Updates the extractor's `timePeriod` mode to support inclusive date ranges while still writing daily files for the transformer:
  - `20260601 20260701` extracts every day from `20260601` through `20260701`
  - each day is requested from Azure as a one-day Cost Details window
  - each day writes files like `system/extracted/AzureMCA/blob/azure_mca_${dataDate}_1.csv`
- Uses documented/proven USE date functions only:
  - `@DATEDIFF(${ARG_2},${ARG_1})` to determine the inclusive loop count
  - `@DATEADD(${extract_date}, 1)` to build each one-day Azure API window
- Replaces the draft MCA transformer logic with the tested preprocess/import pattern:
  - preprocesses `system/extracted/AzureMCA/blob/azure_mca_${dataDate}_1.csv` to `azure_mca_${dataDate}_PP.csv`
  - builds `instance`, `service_key`, `service_name`, `unit` and `category` from the actual Cost Details CSV column names
  - calculates a per-`service_key` rate in `azure.tmp` and correlates it back to detail rows
  - exports to `Exivity/MasterInput/${dataDate}_azure_mca_normalized.csv` for the master transformer
- Updates the master Azure MCA mapping to the tested transformer's output columns (`subscriptionName`, `resourceLocation`, `service_name`, `cogs`).
- Adds a fail-fast guard when Azure returns more than one blob for a day, because the tested transformer currently reads `azure_mca_${dataDate}_1.csv` only.

## Notes

- Existing filenames are unchanged.
- Unrelated local untracked files were not included.